### PR TITLE
Apply v3.0.2

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -50,6 +50,53 @@ jobs:
       - name: Audit
         run: cargo audit
 
+  load-test:
+    name: Async load test
+    needs: build
+    runs-on: ubuntu-latest
+    # Keep normal PR CI fast: only run on the default branch, on manual
+    # dispatch, or on PRs explicitly labelled `load-test`.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.ref == 'refs/heads/main' ||
+      (github.event_name == 'pull_request' &&
+       contains(github.event.pull_request.labels.*.name, 'load-test'))
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: dbms
+          POSTGRES_PASSWORD: dbms
+          POSTGRES_DB: dbms_job
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U dbms -d dbms_job"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 12
+    env:
+      PGHOST: 127.0.0.1
+      PGPORT: "5432"
+      PGUSER: dbms
+      PGPASSWORD: dbms
+      PGDATABASE: dbms_job
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Ensure psql is available
+        run: psql --version || (sudo apt-get update && sudo apt-get install -y postgresql-client)
+
+      - name: Build release binary
+        working-directory: rust
+        run: cargo build --release --bin pg_dbms_job
+
+      - name: Run async load test
+        run: bash ci/load_test.sh
+
   docker:
     needs: build
     runs-on: ubuntu-latest

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -49,6 +49,12 @@ Restart the scheduler binary to pick up the fix.
   cap, reaping finished workers, and blocking-then-logging when saturated), the
   bounded log channel draining a high-volume burst without loss, and
   compile-time sanity bounds on the new tuning constants.
+- A CI load test (`ci/load_test.sh`, wired into the `Async load test` workflow
+  job) that runs the real daemon against a live PostgreSQL, submits a burst of
+  asynchronous jobs, and asserts the queue fully drains and the daemon's peak
+  RSS stays under a ceiling — a regression guard for the bounded-memory work. It
+  runs on the default branch, on manual dispatch, or on PRs labelled
+  `load-test`, so normal PR CI stays fast.
 
 ## 3.0.1 - 2026-06-01
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -28,9 +28,25 @@ Restart the scheduler binary to pick up the fix.
   10 s so a momentarily saturated pool can't pin a worker (and its stack) for
   half a minute. A thread that still fails to spawn leaves the job's dispatch
   marker set, so the stale-job reaper re-queues it instead of losing work.
+- Made the "worker pool full" backpressure cheap and quiet now that it is
+  reached routinely (the cap equals the pool size rather than the old 1024).
+  The dispatcher polls for a free slot on a short fixed interval instead of
+  sleeping a full `error_delay` each time — the coarse wait would otherwise
+  throttle drain throughput to roughly `pool_size` jobs per `error_delay`. The
+  saturation notice is now emitted at LOG level and rate-limited to once per
+  `error_delay` seconds (shared across both dispatch loops) rather than once per
+  poll, so a sustained backlog no longer floods the log.
+
+### Changed
+- Logging no longer holds the global logger lock across the (now bounded,
+  possibly blocking) channel send. The sender is cloned out under the lock and
+  the send happens lock-free, so a backed-up log writer can't stall other
+  threads' logging — including the main dispatch loop — behind one producer.
 
 ### Added
 - Unit tests for the worker-concurrency cap (`effective_max_workers`), the
+  worker-slot backpressure wait (`await_worker_slot`: immediate return below the
+  cap, reaping finished workers, and blocking-then-logging when saturated), the
   bounded log channel draining a high-volume burst without loss, and
   compile-time sanity bounds on the new tuning constants.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,38 @@
 
 All notable changes to this project are documented in this file.
 
+## 3.0.2 - 2026-06-05
+
+Scheduler-only release. The SQL schema is unchanged from 3.0.1;
+`ALTER EXTENSION pg_dbms_job UPDATE TO '3.0.2';` only advances the version.
+Restart the scheduler binary to pick up the fix.
+
+### Fixed
+- Bounded the daemon's memory use under heavy asynchronous-job load, where RSS
+  grew with the number of in-flight jobs and was only released once the backlog
+  drained. Three buffers that scaled with load are now capped:
+  - Worker concurrency is limited to the effective connection-pool size
+    (`min(job_queue_processes, pool_size)`) instead of `job_queue_processes`.
+    Previously a burst could spawn up to `job_queue_processes` (default 1024)
+    threads, most of them blocked waiting on the much smaller pool while each
+    held a thread stack.
+  - Worker threads now use a 512 KiB stack instead of the 2 MiB default, since
+    they only drive SQL over a pooled connection.
+  - The log writer's channel is now bounded, so a logging burst (especially
+    debug logging under load) applies backpressure to producers instead of
+    buffering an unbounded queue of pending lines. No log lines are dropped and
+    timestamps remain accurate (lines are stamped at event time before
+    queueing).
+- Lowered the pooled-connection checkout timeout from r2d2's 30 s default to
+  10 s so a momentarily saturated pool can't pin a worker (and its stack) for
+  half a minute. A thread that still fails to spawn leaves the job's dispatch
+  marker set, so the stale-job reaper re-queues it instead of losing work.
+
+### Added
+- Unit tests for the worker-concurrency cap (`effective_max_workers`), the
+  bounded log channel draining a high-volume burst without loss, and
+  compile-time sanity bounds on the new tuning constants.
+
 ## 3.0.1 - 2026-06-01
 
 Scheduler-only release. The SQL schema is unchanged from 3.0.0;

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Each database that needs to use `pg_dbms_job` must creates the extension:
 
 To upgrade to a new version execute:
 
-    psql -d mydb -c 'ALTER EXTENSION pg_dbms_job UPDATE TO "3.0.2"'
+    psql -d mydb -c "ALTER EXTENSION pg_dbms_job UPDATE TO '3.0.2'"
 
 If you doesn't have the privileges to create an extension you can just import the extension file into the database, for example:
 

--- a/README.md
+++ b/README.md
@@ -83,11 +83,11 @@ Each database that needs to use `pg_dbms_job` must creates the extension:
 
 To upgrade to a new version execute:
 
-    psql -d mydb -c 'ALTER EXTENSION pg_dbms_job UPDATE TO "3.0.1"'
+    psql -d mydb -c 'ALTER EXTENSION pg_dbms_job UPDATE TO "3.0.2"'
 
 If you doesn't have the privileges to create an extension you can just import the extension file into the database, for example:
 
-    psql -d mydb -f sql/pg_dbms_job--3.0.1.sql
+    psql -d mydb -f sql/pg_dbms_job--3.0.2.sql
 
 This is especially useful for database in DBaas cloud services. To upgrade just import the extension upgrade files using psql.
 

--- a/ci/load_test.sh
+++ b/ci/load_test.sh
@@ -89,8 +89,8 @@ echo "::group::Submit $JOBS async jobs"
 # Submit the whole burst BEFORE starting the daemon: on startup the scheduler
 # does a full table scan, so it picks up the entire backlog at once — the
 # heaviest memory path (it materialises every queued row in one fetch).
-psql -v ON_ERROR_STOP=1 -qX -c \
-  "SELECT count(*) AS submitted FROM (SELECT dbms_job.submit('${JOB_BODY}') FROM generate_series(1, ${JOBS})) s;"
+psql -v ON_ERROR_STOP=1 -qX -v job_body="$JOB_BODY" -c \
+  "SELECT count(*) AS submitted FROM (SELECT dbms_job.submit(:'job_body') FROM generate_series(1, ${JOBS})) s;"
 queued="$(psql_scalar "SELECT count(*) FROM dbms_job.all_async_jobs;")"
 echo "queued before start: $queued"
 [ "$queued" -eq "$JOBS" ] || { echo "FAIL: expected $JOBS queued, found $queued"; exit 1; }

--- a/ci/load_test.sh
+++ b/ci/load_test.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+#
+# Async-job load test for the pg_dbms_job scheduler.
+#
+# Submits a burst of asynchronous jobs, runs the real scheduler daemon against a
+# live PostgreSQL, and asserts two things:
+#   1. the async queue drains to zero within a time budget, and
+#   2. the daemon's peak resident memory (VmHWM) stays under a ceiling.
+#
+# The memory check guards the bounded-concurrency / bounded-logging work: with
+# `job_queue_processes` set far above `pool_size`, a regression that removes the
+# worker-count cap would spawn a thread (and a glibc arena) per queued job and
+# blow past the ceiling, while the current code caps live workers at the pool
+# size. The drain check guards correctness — every submitted job must execute.
+#
+# All knobs are overridable via environment variables (see below) so the same
+# script can be run locally against any PostgreSQL.
+set -euo pipefail
+
+# ---- tunables --------------------------------------------------------------
+JOBS="${LOAD_TEST_JOBS:-5000}"                 # async jobs submitted in one burst
+JOB_BODY="${LOAD_TEST_JOB_BODY:-PERFORM pg_sleep(0.1);}"  # keeps a worker busy ~100ms
+DRAIN_TIMEOUT="${LOAD_TEST_DRAIN_TIMEOUT:-180}"          # seconds allowed to fully drain
+RSS_CEILING_KB="${LOAD_TEST_RSS_CEILING_KB:-524288}"     # 512 MiB peak-RSS ceiling
+POOL_SIZE="${LOAD_TEST_POOL_SIZE:-50}"         # pooled connections == max live workers
+QUEUE_PROCESSES="${LOAD_TEST_QUEUE_PROCESSES:-2048}"     # deliberately >> pool_size
+
+BIN="${LOAD_TEST_BIN:-rust/target/release/pg_dbms_job}"
+CONF="${LOAD_TEST_CONF:-/tmp/pg_dbms_job_loadtest.conf}"
+LOG="${LOAD_TEST_LOG:-/tmp/pg_dbms_job_loadtest.log}"
+PIDFILE="${LOAD_TEST_PIDFILE:-/tmp/pg_dbms_job_loadtest.pid}"
+
+export PGHOST="${PGHOST:-127.0.0.1}"
+export PGPORT="${PGPORT:-5432}"
+export PGUSER="${PGUSER:-dbms}"
+export PGPASSWORD="${PGPASSWORD:-dbms}"
+export PGDATABASE="${PGDATABASE:-dbms_job}"
+
+# Scalar query helper: -q quiet, -t tuples-only, -A unaligned, -X no psqlrc.
+psql_scalar() { psql -v ON_ERROR_STOP=1 -qtAX -c "$1"; }
+
+summary() { [ -n "${GITHUB_STEP_SUMMARY:-}" ] && echo "$1" >>"$GITHUB_STEP_SUMMARY" || true; }
+
+cleanup() {
+  # Stop the daemon if it is still running, regardless of how we exit.
+  if [ -f "$PIDFILE" ]; then
+    "$BIN" -c "$CONF" -k >/dev/null 2>&1 || kill "$(cat "$PIDFILE" 2>/dev/null)" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+command -v psql >/dev/null || { echo "psql not found on PATH"; exit 1; }
+[ -x "$BIN" ] || { echo "scheduler binary not found at $BIN"; exit 1; }
+
+EXTVERSION="$(sed -nE "s/.*default_version[[:space:]]*=[[:space:]]*'([^']+)'.*/\1/p" pg_dbms_job.control)"
+
+echo "::group::Install schema (v${EXTVERSION})"
+# The base SQL assumes the dbms_job schema exists (CREATE EXTENSION would create
+# it); for the raw-load path used in CI we create it ourselves first.
+psql -v ON_ERROR_STOP=1 -qX -c "DROP SCHEMA IF EXISTS dbms_job CASCADE; CREATE SCHEMA dbms_job;"
+psql -v ON_ERROR_STOP=1 -qX -f "sql/pg_dbms_job--${EXTVERSION}.sql"
+echo "::endgroup::"
+
+echo "::group::Scheduler config"
+cat >"$CONF" <<EOF
+debug=0
+pidfile=$PIDFILE
+logfile=$LOG
+log_truncate_on_rotation=0
+job_queue_interval=0.5
+job_queue_processes=$QUEUE_PROCESSES
+pool_size=$POOL_SIZE
+nap_time=0.05
+startup_delay=2.0
+error_delay=0.5
+stats_interval=5
+job_run_details=errors
+stale_job_timeout=600
+host=$PGHOST
+port=$PGPORT
+database=$PGDATABASE
+user=$PGUSER
+passwd=$PGPASSWORD
+EOF
+cat "$CONF"
+echo "::endgroup::"
+
+echo "::group::Submit $JOBS async jobs"
+# Submit the whole burst BEFORE starting the daemon: on startup the scheduler
+# does a full table scan, so it picks up the entire backlog at once — the
+# heaviest memory path (it materialises every queued row in one fetch).
+psql -v ON_ERROR_STOP=1 -qX -c \
+  "SELECT count(*) AS submitted FROM (SELECT dbms_job.submit('${JOB_BODY}') FROM generate_series(1, ${JOBS})) s;"
+queued="$(psql_scalar "SELECT count(*) FROM dbms_job.all_async_jobs;")"
+echo "queued before start: $queued"
+[ "$queued" -eq "$JOBS" ] || { echo "FAIL: expected $JOBS queued, found $queued"; exit 1; }
+echo "::endgroup::"
+
+echo "::group::Start scheduler"
+"$BIN" -c "$CONF"   # daemonizes; the parent returns immediately
+PID=""
+for _ in $(seq 1 50); do
+  [ -f "$PIDFILE" ] && PID="$(cat "$PIDFILE")" && [ -n "$PID" ] && break
+  sleep 0.2
+done
+[ -n "$PID" ] && [ -d "/proc/$PID" ] || { echo "FAIL: scheduler did not start"; cat "$LOG" 2>/dev/null || true; exit 1; }
+echo "scheduler pid: $PID"
+echo "::endgroup::"
+
+echo "::group::Drain"
+start="$(date +%s)"
+remaining="$queued"
+while :; do
+  remaining="$(psql_scalar "SELECT count(*) FROM dbms_job.all_async_jobs;")"
+  elapsed=$(( $(date +%s) - start ))
+  if [ "$remaining" -eq 0 ]; then echo "drained in ${elapsed}s"; break; fi
+  if [ "$elapsed" -ge "$DRAIN_TIMEOUT" ]; then echo "TIMEOUT after ${elapsed}s, $remaining jobs left"; break; fi
+  echo "t=${elapsed}s remaining=$remaining"
+  sleep 2
+done
+drain_secs="$elapsed"
+echo "::endgroup::"
+
+# VmHWM is the kernel-tracked peak RSS over the process lifetime, so reading it
+# now (before we stop the daemon) captures the high-water mark during the burst.
+peak_kb="$(awk '/VmHWM/{print $2}' "/proc/$PID/status" 2>/dev/null || echo 0)"
+
+echo "----------------------------------------------------------------"
+echo "jobs submitted : $JOBS"
+echo "drain time     : ${drain_secs}s (timeout ${DRAIN_TIMEOUT}s)"
+echo "remaining jobs : $remaining"
+echo "peak RSS       : ${peak_kb} kB (ceiling ${RSS_CEILING_KB} kB)"
+echo "----------------------------------------------------------------"
+
+summary "### Async load test"
+summary ""
+summary "| metric | value |"
+summary "| --- | --- |"
+summary "| jobs submitted | ${JOBS} |"
+summary "| drain time | ${drain_secs}s / ${DRAIN_TIMEOUT}s |"
+summary "| remaining jobs | ${remaining} |"
+summary "| peak RSS (VmHWM) | ${peak_kb} kB / ${RSS_CEILING_KB} kB ceiling |"
+
+fail=0
+if [ "$remaining" -ne 0 ]; then
+  echo "FAIL: queue did not drain within ${DRAIN_TIMEOUT}s ($remaining jobs left)"; fail=1
+fi
+if [ "$peak_kb" -eq 0 ]; then
+  echo "FAIL: could not read peak RSS for pid $PID"; fail=1
+elif [ "$peak_kb" -gt "$RSS_CEILING_KB" ]; then
+  echo "FAIL: peak RSS ${peak_kb} kB exceeds ceiling ${RSS_CEILING_KB} kB"; fail=1
+fi
+
+if [ "$fail" -ne 0 ]; then
+  echo "==== scheduler log ===="; cat "$LOG" 2>/dev/null || true
+  exit 1
+fi
+
+echo "load test passed"

--- a/pg_dbms_job.control
+++ b/pg_dbms_job.control
@@ -1,5 +1,5 @@
 comment = 'Extension to add Oracle DBMS_JOB full compatibility to PostgreSQL'
-default_version = '3.0.1'
+default_version = '3.0.2'
 module_pathname = '$libdir/pg_dbms_job'
 schema = 'dbms_job'
 relocatable = false

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -3,7 +3,7 @@
 # Licensed under the MIT License; see the LICENSE file at the repository root.
 [package]
 name = "pg_dbms_job"
-version = "3.0.1"
+version = "3.0.2"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT"

--- a/rust/src/constants.rs
+++ b/rust/src/constants.rs
@@ -10,9 +10,69 @@ pub const REAP_INTERVAL_SECS: f64 = 60.0;
 /// Program name used in usage text and messaging, sourced from `Cargo.toml`.
 pub const PROGRAM: &str = env!("CARGO_PKG_NAME");
 
+/// Stack size (bytes) for each per-job worker thread. Workers only issue SQL
+/// over a pooled connection and format short strings — the heavy PL/pgSQL work
+/// happens inside the PostgreSQL backend, not here — so the 2 MiB default stack
+/// is wasteful. Under a burst of async jobs the scheduler can hold one live
+/// thread per in-flight job; a smaller stack keeps that fan-out from ballooning
+/// RSS. 512 KiB leaves ample headroom for the call chain.
+pub const WORKER_STACK_SIZE: usize = 512 * 1024;
+
+/// Bound on the number of pending log lines buffered between the producer
+/// threads and the single writer thread. The channel is intentionally bounded
+/// so a logging burst (e.g. debug logging under heavy async load) applies
+/// backpressure to producers instead of growing memory without limit.
+pub const LOG_CHANNEL_CAPACITY: usize = 16384;
+
+/// Maximum time (seconds) a worker waits to check out a pooled connection
+/// before giving up. With the worker count capped at the pool size a checkout
+/// should almost never block, so this only bounds the worst case (a stalled
+/// backend) instead of letting a worker hold its stack for the r2d2 default of
+/// 30 seconds.
+pub const POOL_CONNECTION_TIMEOUT_SECS: u64 = 10;
+
 #[cfg(test)]
 mod tests {
-    use super::{PROGRAM, VERSION};
+    use super::{
+        LOG_CHANNEL_CAPACITY, POOL_CONNECTION_TIMEOUT_SECS, PROGRAM, VERSION, WORKER_STACK_SIZE,
+    };
+
+    #[test]
+    fn worker_stack_size_is_sane() {
+        // Small enough to keep a burst of in-flight workers from ballooning
+        // RSS (well under the 2 MiB default), but large enough to hold the
+        // worker call chain comfortably.
+        const {
+            assert!(
+                WORKER_STACK_SIZE >= 128 * 1024,
+                "stack too small to be safe"
+            );
+            assert!(
+                WORKER_STACK_SIZE < 2 * 1024 * 1024,
+                "stack should be smaller than the 2 MiB default it replaces"
+            );
+        }
+    }
+
+    #[test]
+    fn log_channel_capacity_is_bounded_and_nonzero() {
+        // Bounded (so logging applies backpressure instead of growing without
+        // limit) yet generous enough to absorb normal bursts without blocking.
+        const {
+            assert!(LOG_CHANNEL_CAPACITY > 0);
+            assert!(LOG_CHANNEL_CAPACITY <= 1 << 20);
+        }
+    }
+
+    #[test]
+    fn pool_connection_timeout_is_shorter_than_r2d2_default() {
+        // We deliberately undercut r2d2's 30s default so a worker can't hold a
+        // stack waiting that long when the pool is momentarily saturated.
+        const {
+            assert!(POOL_CONNECTION_TIMEOUT_SECS > 0);
+            assert!(POOL_CONNECTION_TIMEOUT_SECS < 30);
+        }
+    }
 
     #[test]
     fn constants_are_expected() {

--- a/rust/src/constants.rs
+++ b/rust/src/constants.rs
@@ -1,5 +1,7 @@
 //! Build-time constants for pg_dbms_job.
 
+use std::time::Duration;
+
 /// Current scheduler version string, sourced from `Cargo.toml`.
 pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 /// How often (seconds) the main loop scans for and clears stale dispatch
@@ -31,11 +33,21 @@ pub const LOG_CHANNEL_CAPACITY: usize = 16384;
 /// 30 seconds.
 pub const POOL_CONNECTION_TIMEOUT_SECS: u64 = 10;
 
+/// How long the dispatcher sleeps between checks while waiting for a worker
+/// slot to free up. Now that the worker count is capped at the (typically much
+/// smaller) pool size, this wait is hit routinely under load, so it must be
+/// short: a coarse interval would throttle drain throughput to roughly
+/// `pool_size` jobs per interval. Reaping finished workers is just a handful of
+/// non-blocking `is_finished()` checks, so polling this often is cheap.
+pub const WORKER_SLOT_POLL_INTERVAL: Duration = Duration::from_millis(10);
+
 #[cfg(test)]
 mod tests {
     use super::{
-        LOG_CHANNEL_CAPACITY, POOL_CONNECTION_TIMEOUT_SECS, PROGRAM, VERSION, WORKER_STACK_SIZE,
+        LOG_CHANNEL_CAPACITY, POOL_CONNECTION_TIMEOUT_SECS, PROGRAM, VERSION,
+        WORKER_SLOT_POLL_INTERVAL, WORKER_STACK_SIZE,
     };
+    use std::time::Duration;
 
     #[test]
     fn worker_stack_size_is_sane() {
@@ -62,6 +74,14 @@ mod tests {
             assert!(LOG_CHANNEL_CAPACITY > 0);
             assert!(LOG_CHANNEL_CAPACITY <= 1 << 20);
         }
+    }
+
+    #[test]
+    fn worker_slot_poll_interval_is_short() {
+        // The dispatcher hits this wait routinely under load, so it must stay
+        // small (sub-second) or it would throttle drain throughput.
+        assert!(WORKER_SLOT_POLL_INTERVAL > Duration::ZERO);
+        assert!(WORKER_SLOT_POLL_INTERVAL <= Duration::from_millis(100));
     }
 
     #[test]

--- a/rust/src/db.rs
+++ b/rust/src/db.rs
@@ -1,11 +1,13 @@
 //! Database connection helpers.
 
+use crate::constants::POOL_CONNECTION_TIMEOUT_SECS;
 use crate::logging::dprint;
 use crate::model::{Config, DbInfo};
 use crate::util::die;
 use postgres::{Client, NoTls};
 use r2d2_postgres::PostgresConnectionManager;
 use std::fmt;
+use std::time::Duration;
 
 pub type JobPool = r2d2::Pool<PostgresConnectionManager<NoTls>>;
 pub type PooledJobClient = r2d2::PooledConnection<PostgresConnectionManager<NoTls>>;
@@ -81,6 +83,7 @@ pub fn create_job_pool(dbinfo: &DbInfo, pool_size: u32) -> Result<JobPool, Strin
     r2d2::Pool::builder()
         .max_size(pool_size)
         .min_idle(Some(0))
+        .connection_timeout(Duration::from_secs(POOL_CONNECTION_TIMEOUT_SECS))
         .build(manager)
         .map_err(|e| e.to_string())
 }

--- a/rust/src/jobs.rs
+++ b/rust/src/jobs.rs
@@ -1,5 +1,6 @@
 //! Job discovery and execution logic.
 
+use crate::constants::WORKER_STACK_SIZE;
 use crate::db::{JobPool, get_job_connection, reset_job_connection};
 use crate::dlog;
 use crate::logging::dprint;
@@ -194,13 +195,29 @@ pub fn spawn_job(
     let config_clone = Arc::clone(config);
     let stats_clone = Arc::clone(stats);
 
-    let handle = std::thread::spawn(move || {
-        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            execute_job(kind, job, &pool_clone, &config_clone, &stats_clone);
-        }));
-    });
+    // Workers only drive SQL over a pooled connection, so a small stack is
+    // plenty; the default 2 MiB per thread is what made a burst of in-flight
+    // jobs balloon RSS. See `WORKER_STACK_SIZE`.
+    let spawn_result = std::thread::Builder::new()
+        .name(format!("job-{}", job.job))
+        .stack_size(WORKER_STACK_SIZE)
+        .spawn(move || {
+            let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                execute_job(kind, job, &pool_clone, &config_clone, &stats_clone);
+            }));
+        });
 
-    running_workers.insert(worker_id, handle);
+    match spawn_result {
+        Ok(handle) => {
+            running_workers.insert(worker_id, handle);
+        }
+        Err(err) => {
+            // The dispatch UPDATE already set this_date on the row; leaving it
+            // set means the stale-job reaper re-queues it later, so a transient
+            // thread-spawn failure (e.g. resource exhaustion) doesn't lose work.
+            dlog!(config, "ERROR", "failed to spawn worker thread: {err}");
+        }
+    }
 }
 
 /// Execute a job (async or scheduled) on a pooled connection.

--- a/rust/src/logging.rs
+++ b/rust/src/logging.rs
@@ -54,34 +54,48 @@ static LOG_STATE: Mutex<Option<LoggerState>> = Mutex::new(None);
 /// signal to write to stderr directly rather than panicking — losing logs is
 /// recoverable; killing the scheduler is not.
 fn with_sender<R>(f: impl FnOnce(&mpsc::SyncSender<LogCmd>) -> R) -> Option<R> {
-    let mut guard = match LOG_STATE.lock() {
-        Ok(g) => g,
-        Err(poisoned) => poisoned.into_inner(),
-    };
-    let my_pid = process::id();
-    let need_spawn = match guard.as_ref() {
-        None => true,
-        Some(state) => state.pid != my_pid,
-    };
-    if need_spawn {
-        // Bounded so a logging burst applies backpressure to producers rather
-        // than buffering unbounded — under heavy async load with debug logging
-        // this queue was a primary driver of load-correlated memory growth.
-        let (tx, rx) = mpsc::sync_channel(LOG_CHANNEL_CAPACITY);
-        match std::thread::Builder::new()
-            .name("logger".into())
-            .spawn(move || log_writer_thread(rx))
-        {
-            Ok(_) => {
-                *guard = Some(LoggerState { pid: my_pid, tx });
-            }
-            Err(err) => {
-                eprintln!("ERROR: failed to spawn logger thread ({err}); falling back to stderr");
-                return None;
+    // Clone the sender out under the lock, then RELEASE the lock before calling
+    // `f`. `f` typically does a `send` on the now-bounded channel, which BLOCKS
+    // when the buffer is full. Holding the global `LOG_STATE` mutex across that
+    // blocking send would serialise every other thread's logging behind one
+    // backed-up producer (a lock convoy that could stall the main dispatch loop
+    // under a logging burst). `SyncSender` is cheap to clone (an Arc bump) and
+    // safe to use from multiple producers, so we pay one clone to keep the
+    // critical section short and send lock-free.
+    let sender = {
+        let mut guard = match LOG_STATE.lock() {
+            Ok(g) => g,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        let my_pid = process::id();
+        let need_spawn = match guard.as_ref() {
+            None => true,
+            Some(state) => state.pid != my_pid,
+        };
+        if need_spawn {
+            // Bounded so a logging burst applies backpressure to producers
+            // rather than buffering unbounded — under heavy async load with
+            // debug logging this queue was a primary driver of load-correlated
+            // memory growth.
+            let (tx, rx) = mpsc::sync_channel(LOG_CHANNEL_CAPACITY);
+            match std::thread::Builder::new()
+                .name("logger".into())
+                .spawn(move || log_writer_thread(rx))
+            {
+                Ok(_) => {
+                    *guard = Some(LoggerState { pid: my_pid, tx });
+                }
+                Err(err) => {
+                    eprintln!(
+                        "ERROR: failed to spawn logger thread ({err}); falling back to stderr"
+                    );
+                    return None;
+                }
             }
         }
-    }
-    guard.as_ref().map(|s| f(&s.tx))
+        guard.as_ref().map(|s| s.tx.clone())
+    };
+    sender.as_ref().map(f)
 }
 
 /// Drop any sender inherited from a parent process. Call this in the child

--- a/rust/src/logging.rs
+++ b/rust/src/logging.rs
@@ -5,6 +5,7 @@
 //! per batch.  This avoids per-line open/close syscalls and eliminates
 //! interleaved output from concurrent worker threads.
 
+use crate::constants::LOG_CHANNEL_CAPACITY;
 use crate::model::Config;
 use chrono::Local;
 use std::fs::{self, OpenOptions};
@@ -40,7 +41,7 @@ enum LogCmd {
 /// comparing `pid` against `process::id()` and respawn when they differ.
 struct LoggerState {
     pid: u32,
-    tx: mpsc::Sender<LogCmd>,
+    tx: mpsc::SyncSender<LogCmd>,
 }
 
 static LOG_STATE: Mutex<Option<LoggerState>> = Mutex::new(None);
@@ -52,7 +53,7 @@ static LOG_STATE: Mutex<Option<LoggerState>> = Mutex::new(None);
 /// exhaustion, ulimit, post-fork failure). Callers must treat that case as a
 /// signal to write to stderr directly rather than panicking — losing logs is
 /// recoverable; killing the scheduler is not.
-fn with_sender<R>(f: impl FnOnce(&mpsc::Sender<LogCmd>) -> R) -> Option<R> {
+fn with_sender<R>(f: impl FnOnce(&mpsc::SyncSender<LogCmd>) -> R) -> Option<R> {
     let mut guard = match LOG_STATE.lock() {
         Ok(g) => g,
         Err(poisoned) => poisoned.into_inner(),
@@ -63,7 +64,10 @@ fn with_sender<R>(f: impl FnOnce(&mpsc::Sender<LogCmd>) -> R) -> Option<R> {
         Some(state) => state.pid != my_pid,
     };
     if need_spawn {
-        let (tx, rx) = mpsc::channel();
+        // Bounded so a logging burst applies backpressure to producers rather
+        // than buffering unbounded — under heavy async load with debug logging
+        // this queue was a primary driver of load-correlated memory growth.
+        let (tx, rx) = mpsc::sync_channel(LOG_CHANNEL_CAPACITY);
         match std::thread::Builder::new()
             .name("logger".into())
             .spawn(move || log_writer_thread(rx))
@@ -385,6 +389,29 @@ mod tests {
         flush_logger();
         let content = fs::read_to_string(&path).expect("read log file");
         assert!(content.contains("test message"));
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    fn bounded_channel_drains_high_volume_without_loss() {
+        // Send well past LOG_CHANNEL_CAPACITY so the bounded sync_channel is
+        // forced to apply backpressure (send blocks until the writer drains).
+        // The writer runs concurrently, so this must neither deadlock nor drop
+        // lines: every message sent has to land in the file.
+        use crate::constants::LOG_CHANNEL_CAPACITY;
+        let path = temp_log_path();
+        let config = test_config(&path, false);
+        let count = LOG_CHANNEL_CAPACITY + 5000;
+        for i in 0..count {
+            dprint(&config, "LOG", &format!("bulk message {i}"));
+        }
+        flush_logger();
+        let content = fs::read_to_string(&path).expect("read log file");
+        let lines = content
+            .lines()
+            .filter(|l| l.contains("bulk message"))
+            .count();
+        assert_eq!(lines, count, "bounded channel must not drop log lines");
         let _ = fs::remove_file(path);
     }
 

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -308,13 +308,15 @@ fn main() {
             previous_reap = Instant::now();
         }
 
+        let max_workers = effective_max_workers(&config);
+
         for (_, job) in scheduled_jobs.drain() {
-            while running_workers.len() >= config.job_queue_processes {
+            while running_workers.len() >= max_workers {
                 dlog!(
                     &config,
                     "WARNING",
                     "max job queue size is reached ({}) waiting the end of an other job",
-                    config.job_queue_processes
+                    max_workers
                 );
                 thread::sleep(Duration::from_secs_f64(config.error_delay));
                 reap_children(&mut running_workers);
@@ -331,12 +333,12 @@ fn main() {
         }
 
         for (_, job) in async_jobs.drain() {
-            while running_workers.len() >= config.job_queue_processes {
+            while running_workers.len() >= max_workers {
                 dlog!(
                     &config,
                     "WARNING",
                     "max job queue size is reached ({}) waiting the end of an other job",
-                    config.job_queue_processes
+                    max_workers
                 );
                 thread::sleep(Duration::from_secs_f64(config.error_delay));
                 reap_children(&mut running_workers);
@@ -488,6 +490,19 @@ fn collect_notifications<S: NotificationSource>(
     }
 }
 
+/// The maximum number of concurrent worker threads to keep in flight.
+///
+/// Never run more workers than there are pooled connections: a worker beyond
+/// the pool size can only block in `pool.get()`, holding a thread stack the
+/// whole time. Capping at the effective pool size keeps a burst of async jobs
+/// from spawning up to `job_queue_processes` (default 1024) threads that mostly
+/// sit waiting on the smaller pool — the dominant source of load-driven RSS
+/// growth. Floored at 1 so a degenerate `pool_size = 0` config still makes
+/// forward progress instead of spinning.
+fn effective_max_workers(config: &Config) -> usize {
+    config.job_queue_processes.min(config.pool_size).max(1)
+}
+
 /// Default scheduler configuration values.
 fn default_config() -> Config {
     Config {
@@ -521,7 +536,8 @@ fn default_dbinfo() -> DbInfo {
 #[cfg(test)]
 mod tests {
     use super::{
-        NotificationLike, NotificationSource, collect_notifications, default_config, default_dbinfo,
+        NotificationLike, NotificationSource, collect_notifications, default_config,
+        default_dbinfo, effective_max_workers,
     };
     use std::collections::VecDeque;
     use std::time::{Duration, Instant};
@@ -733,6 +749,34 @@ mod tests {
         // worker threads. Defaults guarantee pool_size <= job_queue_processes.
         let effective = config.pool_size.min(config.job_queue_processes);
         assert_eq!(effective, config.pool_size);
+    }
+
+    #[test]
+    fn effective_max_workers_is_capped_by_pool_size() {
+        // The whole point of the cap: with the defaults (1024 processes, 100
+        // pool) we must never run more than 100 workers, or the surplus threads
+        // just block on the pool holding stacks.
+        let config = default_config();
+        assert_eq!(effective_max_workers(&config), 100);
+        assert_eq!(effective_max_workers(&config), config.pool_size);
+    }
+
+    #[test]
+    fn effective_max_workers_is_capped_by_processes_when_smaller() {
+        // A small job_queue_processes wins over a large pool.
+        let mut config = default_config();
+        config.job_queue_processes = 4;
+        config.pool_size = 100;
+        assert_eq!(effective_max_workers(&config), 4);
+    }
+
+    #[test]
+    fn effective_max_workers_floored_at_one() {
+        // A degenerate pool_size = 0 must still let the loop dispatch one job
+        // at a time rather than busy-spinning on a zero cap.
+        let mut config = default_config();
+        config.pool_size = 0;
+        assert_eq!(effective_max_workers(&config), 1);
     }
 
     #[test]

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -12,7 +12,7 @@ mod util;
 
 use crate::args::{parse_args, usage};
 use crate::config::read_config;
-use crate::constants::{REAP_INTERVAL_SECS, VERSION};
+use crate::constants::{REAP_INTERVAL_SECS, VERSION, WORKER_SLOT_POLL_INTERVAL};
 use crate::db::JobPool;
 use crate::db::{ConnectError, connect_db, create_job_pool};
 use crate::jobs::{get_async_jobs, get_scheduled_jobs, reap_stale_jobs, spawn_job};
@@ -100,6 +100,7 @@ fn main() {
     let mut previous_reap = Instant::now();
     let job_stats = Arc::new(JobStats::default());
     let mut last_stats_at = Instant::now();
+    let mut last_saturation_log: Option<Instant> = None;
     let mut startup = true;
     let mut config_invalidated = false;
     let mut in_recovery_logged = false;
@@ -311,16 +312,12 @@ fn main() {
         let max_workers = effective_max_workers(&config);
 
         for (_, job) in scheduled_jobs.drain() {
-            while running_workers.len() >= max_workers {
-                dlog!(
-                    &config,
-                    "WARNING",
-                    "max job queue size is reached ({}) waiting the end of an other job",
-                    max_workers
-                );
-                thread::sleep(Duration::from_secs_f64(config.error_delay));
-                reap_children(&mut running_workers);
-            }
+            await_worker_slot(
+                &mut running_workers,
+                max_workers,
+                &config,
+                &mut last_saturation_log,
+            );
             spawn_job(
                 JobKind::Scheduled,
                 job,
@@ -333,16 +330,12 @@ fn main() {
         }
 
         for (_, job) in async_jobs.drain() {
-            while running_workers.len() >= max_workers {
-                dlog!(
-                    &config,
-                    "WARNING",
-                    "max job queue size is reached ({}) waiting the end of an other job",
-                    max_workers
-                );
-                thread::sleep(Duration::from_secs_f64(config.error_delay));
-                reap_children(&mut running_workers);
-            }
+            await_worker_slot(
+                &mut running_workers,
+                max_workers,
+                &config,
+                &mut last_saturation_log,
+            );
             spawn_job(
                 JobKind::Async,
                 job,
@@ -503,6 +496,48 @@ fn effective_max_workers(config: &Config) -> usize {
     config.job_queue_processes.min(config.pool_size).max(1)
 }
 
+/// Block until the running-worker count drops below `max_workers`, reaping
+/// finished workers on a short poll interval.
+///
+/// Now that `max_workers` equals the (usually much smaller) pool size, this
+/// backpressure point is reached routinely under load rather than being a
+/// "should never happen" guard, so two things changed from the original
+/// fixed-`error_delay` busy-wait:
+///   * It polls on a short, fixed interval ([`WORKER_SLOT_POLL_INTERVAL`])
+///     instead of `error_delay`. A coarse wait would cap drain throughput at
+///     roughly `max_workers` jobs per interval; reaping is just cheap
+///     non-blocking `is_finished()` checks, so polling fast costs almost
+///     nothing.
+///   * Being at the pool ceiling is normal saturation, not an error, so the
+///     notice is emitted at LOG level and rate-limited to once per
+///     `error_delay` seconds (shared across both dispatch loops via
+///     `last_saturation_log`) instead of once per poll — otherwise a sustained
+///     backlog would flood the log.
+fn await_worker_slot(
+    running_workers: &mut HashMap<u64, JoinHandle<()>>,
+    max_workers: usize,
+    config: &Config,
+    last_saturation_log: &mut Option<Instant>,
+) {
+    reap_children(running_workers);
+    while running_workers.len() >= max_workers {
+        let now = Instant::now();
+        let due = last_saturation_log
+            .is_none_or(|t| now.duration_since(t).as_secs_f64() >= config.error_delay);
+        if due {
+            dlog!(
+                config,
+                "LOG",
+                "worker pool saturated at {} concurrent jobs; further jobs are waiting (raise pool_size for more concurrency)",
+                max_workers
+            );
+            *last_saturation_log = Some(now);
+        }
+        thread::sleep(WORKER_SLOT_POLL_INTERVAL);
+        reap_children(running_workers);
+    }
+}
+
 /// Default scheduler configuration values.
 fn default_config() -> Config {
     Config {
@@ -536,10 +571,12 @@ fn default_dbinfo() -> DbInfo {
 #[cfg(test)]
 mod tests {
     use super::{
-        NotificationLike, NotificationSource, collect_notifications, default_config,
-        default_dbinfo, effective_max_workers,
+        NotificationLike, NotificationSource, await_worker_slot, collect_notifications,
+        default_config, default_dbinfo, effective_max_workers,
     };
-    use std::collections::VecDeque;
+    use std::collections::{HashMap, VecDeque};
+    use std::sync::{Arc, Barrier};
+    use std::thread;
     use std::time::{Duration, Instant};
 
     /// A notification stub carrying only the channel name the tally logic reads.
@@ -768,6 +805,62 @@ mod tests {
         config.job_queue_processes = 4;
         config.pool_size = 100;
         assert_eq!(effective_max_workers(&config), 4);
+    }
+
+    #[test]
+    fn await_worker_slot_returns_immediately_when_below_cap() {
+        let config = default_config();
+        let mut running: HashMap<u64, thread::JoinHandle<()>> = HashMap::new();
+        let mut last = None;
+        // No workers running and a cap of 4: must not block and must not emit a
+        // saturation notice.
+        await_worker_slot(&mut running, 4, &config, &mut last);
+        assert!(running.is_empty());
+        assert!(last.is_none(), "must not log saturation below the cap");
+    }
+
+    #[test]
+    fn await_worker_slot_reaps_finished_without_logging() {
+        let config = default_config();
+        let mut running: HashMap<u64, thread::JoinHandle<()>> = HashMap::new();
+        running.insert(1, thread::spawn(|| {}));
+        thread::sleep(Duration::from_millis(50)); // let it finish
+        let mut last = None;
+        // The up-front reap clears the finished worker so the cap is no longer
+        // reached: it returns without ever entering the wait/log path.
+        await_worker_slot(&mut running, 1, &config, &mut last);
+        assert!(running.is_empty(), "finished worker must be reaped");
+        assert!(last.is_none(), "no wait happened, so no saturation log");
+    }
+
+    #[test]
+    fn await_worker_slot_blocks_until_slot_frees_and_logs_once() {
+        let config = default_config(); // error_delay = 0.5s throttle
+        let mut running: HashMap<u64, thread::JoinHandle<()>> = HashMap::new();
+        let barrier = Arc::new(Barrier::new(2));
+        let b = barrier.clone();
+        running.insert(
+            1,
+            thread::spawn(move || {
+                b.wait();
+            }),
+        );
+        // Release the blocked worker shortly after, from another thread.
+        let b2 = barrier.clone();
+        let releaser = thread::spawn(move || {
+            thread::sleep(Duration::from_millis(30));
+            b2.wait();
+        });
+        let mut last = None;
+        // Cap of 1 with a busy worker: the helper polls until the worker is
+        // released and reaped, then returns.
+        await_worker_slot(&mut running, 1, &config, &mut last);
+        releaser.join().unwrap();
+        assert!(running.is_empty(), "released worker must be reaped");
+        assert!(
+            last.is_some(),
+            "a real wait occurred, so saturation was logged at least once"
+        );
     }
 
     #[test]

--- a/sql/pg_dbms_job--3.0.2.sql
+++ b/sql/pg_dbms_job--3.0.2.sql
@@ -1,0 +1,524 @@
+----
+-- Script to create the base objects of the pg_dbms_job extension
+----
+CREATE SEQUENCE dbms_job.jobseq;
+
+-- Table used to store the jobs to run by the scheduler
+CREATE TABLE dbms_job.all_scheduled_jobs (
+        job bigint DEFAULT nextval('dbms_job.jobseq') PRIMARY KEY, -- identifier of job
+        log_user name DEFAULT current_user, -- user that submit the job
+        priv_user name DEFAULT current_user, -- user whose default privileges apply to this job (not used)
+        schema_user text DEFAULT current_setting('search_path'), -- default schema used to parse the job
+        last_date timestamp with time zone, -- date on which this job last successfully executed
+        last_sec text, -- same as last_date (not used)
+        this_date timestamp with time zone, -- date that this job started executing, null when the job is not running
+        this_sec text, -- same as this_date (not used)
+        next_date timestamp with time zone NOT NULL, -- date that this job will next be executed
+        next_sec timestamp with time zone, -- same as next_date (not used)
+        total_time interval, -- total wall clock time spent by the system on this job, in seconds
+        broken boolean DEFAULT false, -- true: no attempt is made to run this job, false: an attempt is made to run this job
+        interval text, -- a date function, evaluated at the start of execution, becomes next next_date
+        failures bigint, -- number of times the job has started and failed since its last success
+        what text  NOT NULL, -- body of the anonymous pl/sql block that the job executes
+        nls_env text, -- session parameters describing the nls environment of the job (not used)
+	misc_env bytea, -- Other session parameters that apply to this job (not used)
+	instance integer DEFAULT 0 -- ID of the instance that can execute or is executing the job (not used)
+);
+COMMENT ON TABLE dbms_job.all_scheduled_jobs
+    IS 'Table used to store the periodical jobs to run by the scheduler.';
+REVOKE ALL ON dbms_job.all_scheduled_jobs FROM PUBLIC;
+
+-- The user can only see the job that he has created
+ALTER TABLE dbms_job.all_scheduled_jobs ENABLE ROW LEVEL SECURITY;
+CREATE POLICY dbms_job_policy ON dbms_job.all_scheduled_jobs USING (log_user = current_user);
+
+-- Create the asynchronous jobs queue, for immediat execution
+CREATE TABLE dbms_job.all_async_jobs (
+        job bigint DEFAULT nextval('dbms_job.jobseq') PRIMARY KEY, -- identifier of job
+        log_user name DEFAULT current_user, -- user that submit the job
+        schema_user text DEFAULT current_setting('search_path'), -- default search_path used to execute the job
+        create_date timestamp with time zone DEFAULT current_timestamp, -- date on which this job has been created.
+        what text NOT NULL, -- body of the anonymous pl/sql block that the job executes
+        this_date timestamp with time zone -- date that this job started executing, null when the job is not running
+);
+COMMENT ON TABLE dbms_job.all_async_jobs
+    IS 'Table used to store the jobs to be run asynchronously by the scheduler.';
+REVOKE ALL ON dbms_job.all_async_jobs FROM PUBLIC;
+
+-- The user can only see the job that he has created
+ALTER TABLE dbms_job.all_async_jobs ENABLE ROW LEVEL SECURITY;
+CREATE POLICY dbms_job_policy ON dbms_job.all_async_jobs USING (log_user = current_user);
+
+-- Create a view similar to DMBS_JOB.ALL_JOBS
+CREATE VIEW dbms_job.all_jobs AS
+    SELECT * FROM dbms_job.all_scheduled_jobs
+    UNION
+    SELECT job, log_user, NULL priv_user, schema_user, NULL last_date, NULL last_sec,
+           NULL this_date, NULL this_sec, create_date next_date, NULL next_sec, NULL total_time,
+	   'f' broken, NULL "interval", NULL failures, what, NULL nls_env, NULL misc_env,
+	   0 instance FROM dbms_job.all_async_jobs;
+COMMENT ON VIEW dbms_job.all_jobs
+    IS 'View registering all jobs to be run asynchronously or scheduled.';
+REVOKE ALL ON dbms_job.all_jobs FROM PUBLIC;
+
+-- Create a table to store the result of the job execution.
+--
+-- Range-partitioned by log_date (monthly) so the unbounded growth of this
+-- write-only history table is managed by creating/dropping whole partitions
+-- rather than DELETE+VACUUM. log_date is part of the primary key because a
+-- partitioned table's PK must include the partition key. Requires PostgreSQL 11+
+-- (declarative partitioning with a DEFAULT partition).
+CREATE TABLE dbms_job.all_scheduler_job_run_details (
+	log_id bigserial, -- unique identifier of the log entry
+	log_date timestamp with time zone NOT NULL DEFAULT current_timestamp, -- date of the log entry (partition key)
+	owner name, -- owner of the scheduler job
+	job_name varchar(261), -- name of the scheduler job
+	job_subname varchar(261), -- Subname of the Scheduler job (for a chain step job)
+	status text, -- status of the job run
+	error char(5), -- error code in the case of an error
+	req_start_date timestamp with time zone, -- requested start date of the job run
+	actual_start_date timestamp with time zone, -- actual date on which the job was run
+	run_duration bigint, -- duration of the job run in seconds
+	instance_id integer, -- identifier of the instance on which the job was run
+	session_id integer, -- session identifier of the job run
+	slave_pid integer, -- process identifier of the slave on which the job was run
+	cpu_used integer, -- amount of cpu used for the job run
+	additional_info	text, -- additional information on the job run, error message, etc.
+	PRIMARY KEY (log_id, log_date)
+) PARTITION BY RANGE (log_date);
+COMMENT ON TABLE dbms_job.all_scheduler_job_run_details
+    IS 'Table used to store the information about the jobs executed.';
+REVOKE ALL ON dbms_job.all_scheduler_job_run_details FROM PUBLIC;
+
+-- The user can only see the job that he has created
+ALTER TABLE dbms_job.all_scheduler_job_run_details ENABLE ROW LEVEL SECURITY;
+CREATE POLICY dbms_job_policy ON dbms_job.all_scheduler_job_run_details USING (owner = current_user);
+
+----
+-- Partition maintenance for all_scheduler_job_run_details
+--
+-- Ensures a monthly partition exists for the current month and the next
+-- `months_ahead` months (so routine inserts never fall through to the DEFAULT
+-- partition), then drops monthly partitions entirely older than
+-- `retention_months`. Safe to call repeatedly; a missed call only leaves rows
+-- in the DEFAULT partition and pauses pruning — it never breaks inserts.
+--
+-- Schedule it (as a privileged role, since it issues CREATE/DROP TABLE), e.g.
+-- once a day via cron, or by submitting it as a recurring dbms_job:
+--   SELECT dbms_job.submit(
+--       'PERFORM dbms_job.maintain_run_details_partitions();',
+--       current_timestamp,
+--       'current_timestamp + interval ''1 day''');
+----
+CREATE OR REPLACE FUNCTION dbms_job.maintain_run_details_partitions(
+    months_ahead integer DEFAULT 1,
+    retention_months integer DEFAULT 3
+) RETURNS void
+    LANGUAGE PLPGSQL
+    AS $$
+DECLARE
+    start_d date;
+    end_d   date;
+    part    text;
+    cutoff  date;
+    r       record;
+BEGIN
+    FOR i IN 0..GREATEST(months_ahead, 0) LOOP
+        start_d := (date_trunc('month', current_date) + make_interval(months => i))::date;
+        end_d   := (start_d + interval '1 month')::date;
+        part    := 'all_scheduler_job_run_details_' || to_char(start_d, 'YYYYMM');
+        IF NOT EXISTS (
+            SELECT 1 FROM pg_class c
+            JOIN pg_namespace n ON n.oid = c.relnamespace
+            WHERE n.nspname = 'dbms_job' AND c.relname = part
+        ) THEN
+            EXECUTE format(
+                'CREATE TABLE dbms_job.%I PARTITION OF dbms_job.all_scheduler_job_run_details '
+                'FOR VALUES FROM (%L) TO (%L)', part, start_d, end_d);
+        END IF;
+    END LOOP;
+
+    IF retention_months IS NOT NULL AND retention_months > 0 THEN
+        cutoff := (date_trunc('month', current_date)
+                   - make_interval(months => retention_months))::date;
+        FOR r IN
+            SELECT c.relname
+            FROM pg_inherits inh
+            JOIN pg_class c ON c.oid = inh.inhrelid
+            JOIN pg_class p ON p.oid = inh.inhparent
+            JOIN pg_namespace n ON n.oid = p.relnamespace
+            WHERE n.nspname = 'dbms_job'
+              AND p.relname = 'all_scheduler_job_run_details'
+              AND c.relname ~ '^all_scheduler_job_run_details_[0-9]{6}$'
+        LOOP
+            IF to_date(right(r.relname, 6), 'YYYYMM') < cutoff THEN
+                EXECUTE format('DROP TABLE IF EXISTS dbms_job.%I', r.relname);
+            END IF;
+        END LOOP;
+    END IF;
+END;
+$$;
+REVOKE ALL ON FUNCTION dbms_job.maintain_run_details_partitions(integer, integer) FROM PUBLIC;
+
+-- Catch-all partition so inserts never fail even if maintenance lapses, plus
+-- the current and next month's partitions to start with.
+CREATE TABLE dbms_job.all_scheduler_job_run_details_default
+    PARTITION OF dbms_job.all_scheduler_job_run_details DEFAULT;
+SELECT dbms_job.maintain_run_details_partitions(1, 3);
+
+----
+-- Indexes supporting the scheduler dispatch scans
+--
+-- The daemon refetches ready jobs on every cycle. Without these partial
+-- indexes both fetches degrade to sequential scans over the whole table,
+-- which dominates dispatch latency once the tables accumulate rows/bloat.
+-- The indexes are partial on `this_date IS NULL` so they only cover the
+-- small set of not-yet-running jobs, matching the WHERE clauses in
+-- jobs.rs::get_async_jobs / get_scheduled_jobs.
+----
+CREATE INDEX IF NOT EXISTS all_async_jobs_pending_idx
+    ON dbms_job.all_async_jobs (job)
+    WHERE this_date IS NULL;
+CREATE INDEX IF NOT EXISTS all_scheduled_jobs_pending_idx
+    ON dbms_job.all_scheduled_jobs (next_date)
+    WHERE this_date IS NULL;
+
+----
+-- Per-table autovacuum tuning for the queue tables
+--
+-- Each dispatch+completion performs an UPDATE per job, so these tables churn
+-- heavily and bloat fast under the default 20% scale factor. Vacuum/analyze
+-- them aggressively (after ~100 dead tuples, no cost-delay throttling) so the
+-- partial indexes above and the dispatch scans stay on a compact heap.
+----
+ALTER TABLE dbms_job.all_async_jobs SET (
+    autovacuum_vacuum_scale_factor = 0.0,
+    autovacuum_vacuum_threshold = 100,
+    autovacuum_analyze_scale_factor = 0.0,
+    autovacuum_analyze_threshold = 100,
+    autovacuum_vacuum_cost_delay = 0
+);
+ALTER TABLE dbms_job.all_scheduled_jobs SET (
+    autovacuum_vacuum_scale_factor = 0.0,
+    autovacuum_vacuum_threshold = 100,
+    autovacuum_analyze_scale_factor = 0.0,
+    autovacuum_analyze_threshold = 100,
+    autovacuum_vacuum_cost_delay = 0
+);
+
+----
+-- Stored procedures
+----
+CREATE PROCEDURE dbms_job.broken(
+		jobid     IN  bigint,
+		broken    IN  boolean,
+		next_date IN  timestamp with time zone DEFAULT current_timestamp)
+    LANGUAGE PLPGSQL
+    AS $$
+BEGIN
+    -- interval must be in the future
+    IF next_date < current_timestamp THEN
+        RAISE EXCEPTION 'next_val must be a time in the future: %', next_date USING ERRCODE = '23420';
+    END IF;
+    UPDATE dbms_job.all_scheduled_jobs SET broken=$2,next_date=$3 WHERE job=$1;
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'null_value_not_allowed' USING detail = 'job number is not a job in the job queue';
+    END IF;
+END;
+$$;
+
+COMMENT ON PROCEDURE dbms_job.broken(bigint,boolean,timestamp with time zone)
+    IS 'Disables job execution. Broken jobs are never run.';
+REVOKE ALL ON PROCEDURE dbms_job.broken FROM PUBLIC;
+
+CREATE PROCEDURE dbms_job.change(
+		job          IN  bigint,
+		what         IN  text,
+		next_date    IN  timestamp with time zone,
+		job_interval IN  text,
+		instance     IN  bigint DEFAULT 0,
+		force        IN  boolean DEFAULT false)
+    LANGUAGE PLPGSQL 
+    AS $$
+DECLARE
+    cols_modified text;
+    future_date timestamp with time zone;
+    v_ret bigint;
+BEGIN
+    -- If what, next_date or job_interval are NULL they are kept unchanged
+    IF what IS NOT NULL THEN
+	cols_modified := coalesce(cols_modified, '') || 'what=' || quote_literal(what) || ','; 
+    END IF;
+    IF next_date IS NOT NULL THEN
+	cols_modified := coalesce(cols_modified, '') || 'next_date=' || quote_literal(next_date) || ','; 
+    END IF;
+    IF job_interval IS NOT NULL THEN
+        -- interval must be in the future
+        future_date := dbms_job.get_next_date(job_interval);
+        IF future_date < current_timestamp THEN
+    	    RAISE EXCEPTION 'Interval must evaluate to a time in the future: %', future_date USING ERRCODE = '23420';
+        END IF;
+	cols_modified := coalesce(cols_modified, '') || 'interval=' || quote_literal(job_interval) || ','; 
+    END IF;
+    IF cols_modified IS NOT NULL THEN
+        EXECUTE 'UPDATE dbms_job.all_scheduled_jobs SET ' || rtrim(cols_modified, ',') || ' WHERE job=$1 RETURNING job'INTO v_ret USING job;
+        IF v_ret IS NULL THEN
+            RAISE EXCEPTION 'null_value_not_allowed' USING detail = 'job number is not a job in the job queue';
+        END IF;
+    END IF;
+END;
+$$;
+COMMENT ON PROCEDURE dbms_job.change(bigint,text,timestamp with time zone,text,bigint,boolean)
+    IS 'Alters any of the user-definable parameters associated with a job';
+REVOKE ALL ON PROCEDURE dbms_job.change FROM PUBLIC;
+
+CREATE PROCEDURE dbms_job.interval(
+		jobid           IN  bigint,
+		job_interval  IN  text)
+    LANGUAGE PLPGSQL 
+    AS $$
+DECLARE
+    next_date timestamp with time zone;
+    v_interval text;
+    v_retval bigint;
+BEGIN
+    IF job_interval IS NULL THEN
+        UPDATE dbms_job.all_scheduled_jobs SET interval = NULL WHERE job = jobid;
+    ELSE
+        -- interval must be in the future
+        next_date := dbms_job.get_next_date(job_interval);
+        IF next_date < current_timestamp THEN
+    	    RAISE EXCEPTION 'Interval must evaluate to a time in the future: %', next_date USING ERRCODE = '23420';
+        END IF;
+        v_interval := 'UPDATE dbms_job.all_scheduled_jobs SET interval = ' || quote_literal(job_interval) || ' WHERE job = ' || jobid || ' RETURNING job';
+        EXECUTE v_interval INTO v_retval;
+        IF v_retval IS NULL THEN
+            RAISE EXCEPTION 'null_value_not_allowed' USING detail = 'job number is not a job in the job queue';
+        END IF;
+    END IF;
+END;
+$$;
+
+COMMENT ON PROCEDURE dbms_job.interval(bigint,text)
+    IS 'Alters the interval between executions for a specified job';
+REVOKE ALL ON PROCEDURE dbms_job.interval FROM PUBLIC;
+
+CREATE PROCEDURE dbms_job.next_date(
+		jobid        IN  bigint,
+		next_date  IN  timestamp with time zone)
+    LANGUAGE PLPGSQL
+    AS $$
+BEGIN
+    IF next_date IS NULL THEN
+        RAISE EXCEPTION 'Next date can not be NULL';
+    END IF;
+    UPDATE dbms_job.all_scheduled_jobs SET next_date = $2 WHERE job = jobid;
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'null_value_not_allowed' USING detail = 'job number is not a job in the job queue';
+    END IF;
+END;
+$$;
+
+COMMENT ON PROCEDURE dbms_job.next_date(bigint,timestamp with time zone)
+    IS 'Alters the next execution time for a specified job';
+REVOKE ALL ON PROCEDURE dbms_job.next_date FROM PUBLIC;
+
+CREATE PROCEDURE dbms_job.remove(
+		jobid        IN  bigint)
+    LANGUAGE PLPGSQL
+    AS $$
+BEGIN
+    DELETE FROM dbms_job.all_scheduled_jobs WHERE job = jobid;
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'null_value_not_allowed' USING detail = 'job number is not a job in the job queue';
+    END IF;
+END;
+$$;
+
+COMMENT ON PROCEDURE dbms_job.remove(bigint)
+    IS 'Removes specified job from the job queue';
+REVOKE ALL ON PROCEDURE dbms_job.remove FROM PUBLIC;
+
+CREATE PROCEDURE dbms_job.run(
+		jobid   IN bigint,
+		force   IN boolean DEFAULT false)
+    LANGUAGE PLPGSQL
+    AS $$
+DECLARE
+    v_what    text;
+    tmp_what  text;
+    start_t   timestamp with time zone;
+    end_t     timestamp with time zone;
+    v_state   text;
+    v_msg     text;
+    v_detail  text;
+    v_hint    text;
+    v_context text;
+BEGIN
+    IF jobid IS NULL THEN
+	RETURN;
+    END IF;
+    -- Get the job definition
+    SELECT what INTO v_what FROM dbms_job.all_scheduled_jobs WHERE job = jobid;
+    IF v_what IS NULL THEN
+        RAISE EXCEPTION 'null_value_not_allowed' USING detail = 'job number is not a job in the job queue';
+    END IF;
+    -- When force is false execute the job immediatly in foreground
+    IF NOT force THEN
+        start_t :=  clock_timestamp();
+	-- Remove BEGIN/END from the code
+	SELECT regexp_replace(v_what, 'BEGIN\s+(.*)\s*END;', '\1', 'i') INTO tmp_what;
+        UPDATE dbms_job.all_scheduled_jobs SET this_date = start_t WHERE job = jobid;
+        BEGIN
+    	EXECUTE tmp_what;
+        EXCEPTION
+    	WHEN others THEN
+    	    -- Increase the failure count
+    	    UPDATE dbms_job.all_scheduled_jobs SET
+	        failures = failures + 1
+	    WHERE job = jobid;
+	    -- Rethrow the exception
+	    RAISE;
+        END;
+        end_t :=  clock_timestamp();
+        -- Update job's statistics
+        UPDATE dbms_job.all_scheduled_jobs SET 
+            last_date = end_t,
+            this_date = NULL,
+            total_time = total_time + ((EXTRACT(EPOCH FROM end_t) - EXTRACT(EPOCH FROM start_t)) || ' seconds')::interval,
+            failures = 0,
+            instance = instance+1,
+            broken = false,
+	    next_date = dbms_job.get_next_date(interval)
+        WHERE job = jobid;
+	-- No write to history table in foreground mode
+    ELSE
+        -- Execute the job in background by submitting an asynchronous job
+	SELECT dbms_job.submit(v_what) INTO jobid;
+    END IF;
+END;
+$$;
+COMMENT ON PROCEDURE dbms_job.run(bigint, boolean)
+    IS 'Forces a specified job to run immediatly. It runs even if it is broken';
+REVOKE ALL ON PROCEDURE dbms_job.run FROM PUBLIC;
+
+CREATE FUNCTION dbms_job.submit(
+		jobid         OUT   bigint,
+		what          IN    text,
+		next_date     IN    timestamp with time zone DEFAULT current_timestamp,
+		job_interval  IN    text DEFAULT NULL,
+		no_parse      IN    boolean DEFAULT false)
+    RETURNS bigint
+    LANGUAGE PLPGSQL
+    AS $$
+BEGIN
+    -- interval must be in the future
+    IF next_date < current_timestamp THEN
+        RAISE EXCEPTION 'next_date must be a time in the future: %', next_date USING ERRCODE = '23420';
+    END IF;
+    -- When an interval is defined this is a job to be scheduled
+    IF job_interval IS NOT NULL THEN
+        INSERT INTO dbms_job.all_scheduled_jobs (what,next_date,interval) VALUES ($2,$3,$4) RETURNING job INTO jobid;
+    ELSE
+	-- With no interval verify if the job is planned in
+	-- the future or that it must be executed immediatly
+        IF next_date > current_timestamp THEN
+            INSERT INTO dbms_job.all_scheduled_jobs (what,next_date,interval) VALUES ($2,$3,$4) RETURNING job INTO jobid;
+        ELSE
+            -- This is an immediate asynchronous execution, use the special queue
+            INSERT INTO dbms_job.all_async_jobs (what) VALUES ($2) RETURNING job INTO jobid;
+        END IF;
+    END IF;
+END;
+$$;
+COMMENT ON FUNCTION dbms_job.submit(text,timestamp with time zone,text,boolean)
+    IS 'Submits a new job to the job queue.';
+REVOKE ALL ON FUNCTION dbms_job.submit FROM PUBLIC;
+
+CREATE PROCEDURE dbms_job.what(
+		job       IN  bigint,
+		what      IN  text)
+    LANGUAGE SQL
+    AS 'UPDATE dbms_job.all_scheduled_jobs SET what=$2 WHERE job=$1';
+COMMENT ON PROCEDURE dbms_job.what(bigint,text)
+    IS 'Alters the job description for a specified job';
+REVOKE ALL ON PROCEDURE dbms_job.what FROM PUBLIC;
+
+CREATE FUNCTION dbms_job.job_scheduled_notify()
+    RETURNS trigger
+    LANGUAGE PLPGSQL
+    AS $$
+BEGIN
+    -- Force interval to be NULL if this is set to an empty string
+    IF TG_OP = 'UPDATE' OR TG_OP = 'INSERT' THEN
+        IF NEW.interval = '' THEN
+            NEW.interval := NULL;
+        END IF;
+    END IF;
+    -- When a change occurs in the all_scheduled_jobs table, notify the scheduler.
+    IF TG_OP = 'UPDATE' THEN
+	-- We do not notify the scheduler if it is at the origine of the UPDATE.
+        -- We increment the value of the instance column when this is an internal
+	-- update after an execution.
+        IF NEW.instance = OLD.instance THEN
+	    PERFORM pg_notify('dbms_job_scheduled_notify', TG_OP || ':' || OLD.job || ':' || NEW.job);
+        END IF;
+	RETURN NEW;
+    END IF;
+    IF TG_OP = 'INSERT' THEN
+	PERFORM pg_notify('dbms_job_scheduled_notify', TG_OP || ':' || NEW.job);
+	RETURN NEW;
+    END IF;
+    IF TG_OP = 'DELETE' THEN
+	PERFORM pg_notify('dbms_job_scheduled_notify', TG_OP || ':' || OLD.job);
+	RETURN OLD;
+    END IF;
+    -- TRUNCATE
+    PERFORM pg_notify('dbms_job_scheduled_notify', TG_OP);
+    RETURN OLD;
+END;
+$$;
+COMMENT ON FUNCTION dbms_job.job_scheduled_notify()
+    IS 'Notify the scheduler that the job cache must be invalidated';
+
+-- When there is a modification in the JOB table invalidate the cache
+-- to inform the background worker to reread the table
+CREATE TRIGGER dbms_job_scheduled_notify_trg
+    AFTER INSERT OR UPDATE OR DELETE OR TRUNCATE
+    ON dbms_job.all_scheduled_jobs
+    FOR STATEMENT EXECUTE FUNCTION dbms_job.job_scheduled_notify();
+
+CREATE FUNCTION dbms_job.job_async_notify()
+    RETURNS trigger
+    LANGUAGE PLPGSQL
+    AS $$
+BEGIN
+    -- When a new async job is submitted, notify the scheduler
+    PERFORM pg_notify('dbms_job_async_notify', 'New asynchronous job received');
+    RETURN NEW;
+END;
+$$;
+COMMENT ON FUNCTION dbms_job.job_async_notify()
+    IS 'Notify the scheduler that a new asynchronous job was submitted';
+
+-- When there is a new asynchronous job submited
+-- to inform the daemon to reread the table
+CREATE TRIGGER dbms_job_async_notify_trg
+    AFTER INSERT
+    ON dbms_job.all_async_jobs
+    FOR STATEMENT EXECUTE FUNCTION dbms_job.job_async_notify();
+
+CREATE FUNCTION dbms_job.get_next_date(text)
+    RETURNS timestamp with time zone
+    LANGUAGE PLPGSQL
+    AS $$
+DECLARE
+    next_date timestamp with time zone;
+BEGIN
+	EXECUTE 'SELECT '||$1 INTO next_date;
+	RETURN next_date;
+END;
+$$;
+COMMENT ON FUNCTION dbms_job.get_next_date(text)
+    IS 'Used to get the next date returned by the interval code';
+

--- a/sql/pg_dbms_job--3.0.2.sql
+++ b/sql/pg_dbms_job--3.0.2.sql
@@ -218,7 +218,7 @@ CREATE PROCEDURE dbms_job.broken(
 BEGIN
     -- interval must be in the future
     IF next_date < current_timestamp THEN
-        RAISE EXCEPTION 'next_val must be a time in the future: %', next_date USING ERRCODE = '23420';
+        RAISE EXCEPTION 'next_date must be a time in the future: %', next_date USING ERRCODE = '23420';
     END IF;
     UPDATE dbms_job.all_scheduled_jobs SET broken=$2,next_date=$3 WHERE job=$1;
     IF NOT FOUND THEN

--- a/updates/pg_dbms_job--3.0.1--3.0.2.sql
+++ b/updates/pg_dbms_job--3.0.1--3.0.2.sql
@@ -1,0 +1,14 @@
+----
+-- Upgrade pg_dbms_job from 3.0.1 to 3.0.2.
+--
+-- Run with: ALTER EXTENSION pg_dbms_job UPDATE TO '3.0.2';
+--
+-- 3.0.2 is a scheduler-only release: it bounds the Rust daemon's memory use
+-- under heavy asynchronous-job load. Worker concurrency is now capped at the
+-- effective connection-pool size (instead of job_queue_processes), worker
+-- threads use a small stack, and the log writer's channel is bounded so a
+-- logging burst applies backpressure instead of growing without limit. The SQL
+-- schema is unchanged from 3.0.1, so this migration intentionally does nothing
+-- but advance the extension version. Restart the scheduler binary to pick up
+-- the fix.
+----


### PR DESCRIPTION
## 3.0.2 - 2026-06-05

Scheduler-only release. The SQL schema is unchanged from 3.0.1;
`ALTER EXTENSION pg_dbms_job UPDATE TO '3.0.2';` only advances the version.
Restart the scheduler binary to pick up the fix.

### Fixed
- Bounded the daemon's memory use under heavy asynchronous-job load, where RSS
  grew with the number of in-flight jobs and was only released once the backlog
  drained. Three buffers that scaled with load are now capped:
  - Worker concurrency is limited to the effective connection-pool size
    (`min(job_queue_processes, pool_size)`) instead of `job_queue_processes`.
    Previously a burst could spawn up to `job_queue_processes` (default 1024)
    threads, most of them blocked waiting on the much smaller pool while each
    held a thread stack.
  - Worker threads now use a 512 KiB stack instead of the 2 MiB default, since
    they only drive SQL over a pooled connection.
  - The log writer's channel is now bounded, so a logging burst (especially
    debug logging under load) applies backpressure to producers instead of
    buffering an unbounded queue of pending lines. No log lines are dropped and
    timestamps remain accurate (lines are stamped at event time before
    queueing).
- Lowered the pooled-connection checkout timeout from r2d2's 30 s default to
  10 s so a momentarily saturated pool can't pin a worker (and its stack) for
  half a minute. A thread that still fails to spawn leaves the job's dispatch
  marker set, so the stale-job reaper re-queues it instead of losing work.
- Made the "worker pool full" backpressure cheap and quiet now that it is
  reached routinely (the cap equals the pool size rather than the old 1024).
  The dispatcher polls for a free slot on a short fixed interval instead of
  sleeping a full `error_delay` each time — the coarse wait would otherwise
  throttle drain throughput to roughly `pool_size` jobs per `error_delay`. The
  saturation notice is now emitted at LOG level and rate-limited to once per
  `error_delay` seconds (shared across both dispatch loops) rather than once per
  poll, so a sustained backlog no longer floods the log.

### Changed
- Logging no longer holds the global logger lock across the (now bounded,
  possibly blocking) channel send. The sender is cloned out under the lock and
  the send happens lock-free, so a backed-up log writer can't stall other
  threads' logging — including the main dispatch loop — behind one producer.

### Added
- Unit tests for the worker-concurrency cap (`effective_max_workers`), the
  worker-slot backpressure wait (`await_worker_slot`: immediate return below the
  cap, reaping finished workers, and blocking-then-logging when saturated), the
  bounded log channel draining a high-volume burst without loss, and
  compile-time sanity bounds on the new tuning constants.
- A CI load test (`ci/load_test.sh`, wired into the `Async load test` workflow
  job) that runs the real daemon against a live PostgreSQL, submits a burst of
  asynchronous jobs, and asserts the queue fully drains and the daemon's peak
  RSS stays under a ceiling — a regression guard for the bounded-memory work. It
  runs on the default branch, on manual dispatch, or on PRs labelled
  `load-test`, so normal PR CI stays fast.